### PR TITLE
#164456667 Politico send password reset link to email address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - pytest --cov=app/api/v2 tests/v2
+  - pytest --cov=app/api tests/
 
 after_success:
   - coveralls

--- a/app/api/database/database.py
+++ b/app/api/database/database.py
@@ -6,13 +6,13 @@ class Database():
     def __init__(self, query, retrieve=False):
         self.query = query
         self.retrieve = retrieve
+        self.conn = psycopg2.connect("postgres://jiduvlmktqoqzc:36ae1622f107d8f8f5b0641425ba417f1f29cf525b3b544db3136b8502117151@ec2-23-23-184-76.compute-1.amazonaws.com:5432/d88et68214thdv", sslmode='require')
   
     def executeQuery(self):
         try:
-            conn = psycopg2.connect("postgres://jiduvlmktqoqzc:36ae1622f107d8f8f5b0641425ba417f1f29cf525b3b544db3136b8502117151@ec2-23-23-184-76.compute-1.amazonaws.com:5432/d88et68214thdv", sslmode='require')
-            cursor = conn.cursor()
+            cursor = self.conn.cursor()
             cursor.execute(self.query)
-            conn.commit()
+            self.conn.commit()
             if self.retrieve is True:
                 col = [desc[0] for desc in cursor.description]
                 results = []
@@ -33,6 +33,6 @@ class Database():
                 "status": 400
             }
         finally:
-            if(conn):
+            if(self.conn):
                 cursor.close()
-                conn.close()
+                self.conn.close()

--- a/app/api/database/schemaGenerator/schemaGenerator.py
+++ b/app/api/database/schemaGenerator/schemaGenerator.py
@@ -29,15 +29,19 @@ class SchemaGenerator():
     def updateSpecific(self):
         string = ""
         result = []
+        count = 0
         for x in self.data:
             col = x
             row = self.data[x]
             string = col + " = '" + row + "'"
             result.append(string)
-
+            count += 1
+        output = str(tuple(result)).replace('"', '').replace('(', '').replace(')', '')
+        if count <= 1:
+            output = output.replace(",", "")
         return """
             UPDATE """ + self.tableName + """ 
-            SET """ + str(tuple(result)).replace('"', '').replace('(', '').replace(')', '') + """
+            SET """ + output + """
             WHERE id = """ + self.id + """
         """
 

--- a/app/api/v2/models/auth/auth_model.py
+++ b/app/api/v2/models/auth/auth_model.py
@@ -73,10 +73,10 @@ class AuthModel():
     def sendResetEmail(self, user):
         try:
             fullName = user["first_name"] + " " + user["last_name"]
-            link = "http://127.0.0.1:8080/UI/auth/reset.html?token=" + self.token
+            link = "http://127.0.0.1:8080/UI/auth/reset.html?token=" + self.token + "&id=" + str(user["id"])
             sg = sendgrid.SendGridAPIClient(apikey="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")
             from_email = Email("politico-noreply@politico.com")
-            to_email = Email("jama3137@gmail.com")
+            to_email = Email(user["email"])
             subject = "Politico Password Reset"
             message = '''
                 <!DOCTYPE html>
@@ -218,7 +218,7 @@ class AuthModel():
             '''
             content = Content("text/html", message)
             mail = Mail(from_email, subject, to_email, content)
-            response = sg.client.mail.send.post(request_body=mail.get())
+            sg.client.mail.send.post(request_body=mail.get())
             return self.token
         except:
             return "error"

--- a/app/api/v2/models/auth/auth_model.py
+++ b/app/api/v2/models/auth/auth_model.py
@@ -5,14 +5,16 @@ from app.api.database.schemaGenerator.schemaGenerator import SchemaGenerator
 from app.api.database.database import Database
 import sendgrid
 from sendgrid.helpers.mail import Email, Content, Mail
+from flask_jwt_extended import create_access_token
 
 
 class AuthModel():
-    def __init__(self, data=None, id=None):
+    def __init__(self, data=None, id=None, token=None):
         self.tableName = "users"
         if data is not None:
             self.data = checkIfValuesHaveFirstLetterUpperCase(data)
         self.id = id
+        self.token = token
 
     def registerUser(self):
         valid = validate(self.tableName, self.data)
@@ -56,6 +58,7 @@ class AuthModel():
         try:
             fullName = user["first_name"] + " " + user["last_name"]
             link = ""
+            print(self.token)
             sg = sendgrid.SendGridAPIClient(apikey="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")
             from_email = Email("politico-noreply@politico.com")
             to_email = Email("jama3137@gmail.com")
@@ -201,9 +204,7 @@ class AuthModel():
             content = Content("text/html", message)
             mail = Mail(from_email, subject, to_email, content)
             response = sg.client.mail.send.post(request_body=mail.get())
-            print(response.status_code)
-            print(response.body)
-            print(response.headers)
+            print("email sent")
         except:
             print("the was an error")
 
@@ -228,5 +229,5 @@ class AuthModel():
         self.sendResetEmail(db["data"][0])
         return returnMessages.success(200, {
             "data": db["data"][0],
-            "msg": "User retrieved successfully"
+            "msg": db["data"][0]["email"]
         })

--- a/app/api/v2/models/auth/auth_model.py
+++ b/app/api/v2/models/auth/auth_model.py
@@ -49,3 +49,26 @@ class AuthModel():
             "user": db["data"][0],
             "msg": "Login successfull"
         })
+
+    def getSpecificUser(self):
+        schema = SchemaGenerator(self.tableName, "email", None, "'" + self.id + "'").selectSpecific()
+        db = Database(schema, True).executeQuery()
+        if db["status"] == 400:
+            return {
+                "status": db["status"],
+                "error": db["error"]
+            }
+        if not db["data"]:
+            return {
+                "status": 404,
+                "error": "The user was not found"
+            }
+        if db["data"][0]["email"] == "admin@gmail.com":
+            return {
+                "status": 401,
+                "error": "You are fobidden to reset admin account"
+            }
+        return returnMessages.success(200, {
+            "data": db["data"],
+            "msg": "User retrieved successfully"
+        })

--- a/app/api/v2/models/auth/auth_model.py
+++ b/app/api/v2/models/auth/auth_model.py
@@ -3,6 +3,8 @@ from app.api.v2.utils.validations.validation import checkIfValuesHaveFirstLetter
 from app.api.v2.utils.returnMessages import returnMessages
 from app.api.database.schemaGenerator.schemaGenerator import SchemaGenerator
 from app.api.database.database import Database
+import sendgrid
+from sendgrid.helpers.mail import Email, Content, Mail
 
 
 class AuthModel():
@@ -50,6 +52,161 @@ class AuthModel():
             "msg": "Login successfull"
         })
 
+    def sendResetEmail(self, user):
+        try:
+            fullName = user["first_name"] + " " + user["last_name"]
+            link = ""
+            sg = sendgrid.SendGridAPIClient(apikey="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")
+            from_email = Email("politico-noreply@politico.com")
+            to_email = Email("jama3137@gmail.com")
+            subject = "Politico Password Reset"
+            message = '''
+                <!DOCTYPE html>
+                <html>
+
+                <head>
+                <title>Password Reset</title>
+                <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+                <meta content="width=device-width" name="viewport">
+                <style type="text/css">
+                    @font-face {
+                    font-family: &#x27;
+                    Postmates Std&#x27;
+                    ;
+                    font-weight: 600;
+                    font-style: normal;
+                    src: local(&#x27;
+                    Postmates Std Bold&#x27;
+                    ),
+                    url(https://s3-us-west-1.amazonaws.com/buyer-static.postmates.com/assets/email/postmates-std-bold.woff) format(&#x27;
+                    woff&#x27;
+                    );
+                    }
+
+                    @font-face {
+                    font-family: &#x27;
+                    Postmates Std&#x27;
+                    ;
+                    font-weight: 500;
+                    font-style: normal;
+                    src: local(&#x27;
+                    Postmates Std Medium&#x27;
+                    ),
+                    url(https://s3-us-west-1.amazonaws.com/buyer-static.postmates.com/assets/email/postmates-std-medium.woff) format(&#x27;
+                    woff&#x27;
+                    );
+                    }
+
+                    @font-face {
+                    font-family: &#x27;
+                    Postmates Std&#x27;
+                    ;
+                    font-weight: 400;
+                    font-style: normal;
+                    src: local(&#x27;
+                    Postmates Std Regular&#x27;
+                    ),
+                    url(https://s3-us-west-1.amazonaws.com/buyer-static.postmates.com/assets/email/postmates-std-regular.woff) format(&#x27;
+                    woff&#x27;
+                    );
+                    }
+                </style>
+                <style media="screen and (max-width: 680px)">
+                    @media screen and (max-width: 680px) {
+                    .page-center {
+                        padding-left: 0 !important;
+                        padding-right: 0 !important;
+                    }
+
+                    .footer-center {
+                        padding-left: 20px !important;
+                        padding-right: 20px !important;
+                    }
+                    }
+                </style>
+                </head>
+
+                <body style="background-color: #f4f4f5;">
+                <table cellpadding="0" cellspacing="0"
+                    style="width: 100%; height: 100%; background-color: #f4f4f5; text-align: center;">
+                    <tbody>
+                    <tr>
+                        <td style="text-align: center;">
+                        <table align="center" cellpadding="0" cellspacing="0" id="body"
+                            style="background-color: #fff; width: 100%; max-width: 680px; height: 100%;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                <table align="center" cellpadding="0" cellspacing="0" class="page-center"
+                                    style="text-align: left; padding-bottom: 88px; width: 100%; padding-left: 120px; padding-right: 120px;">
+                                    <tbody>
+                                    <tr>
+                                        <td colspan="2"
+                                        style="padding-top: 72px; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; color: #F57C00; font-family: 'Postmates Std', 'Helvetica', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 48px; font-smoothing: always; font-style: normal; font-weight: 600; letter-spacing: -2.6px; line-height: 52px; mso-line-height-rule: exactly; text-decoration: none;">
+                                        Politico Reset Password</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding-top: 48px; padding-bottom: 48px;">
+                                        <table cellpadding="0" cellspacing="0" style="width: 100%">
+                                            <tbody>
+                                            <tr>
+                                                <td
+                                                style="width: 100%; height: 1px; max-height: 1px; background-color: #d9dbe0; opacity: 0.81">
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                        style="-ms-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; color: #9095a2; font-family: 'Postmates Std', 'Helvetica', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 16px; font-smoothing: always; font-style: normal; font-weight: 400; letter-spacing: -0.18px; line-height: 24px; mso-line-height-rule: exactly; text-decoration: none; vertical-align: top; width: 100%;">
+                                        <h5>Hey, ''' + fullName + '''</h5>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                        style="-ms-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; color: #9095a2; font-family: 'Postmates Std', 'Helvetica', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 16px; font-smoothing: always; font-style: normal; font-weight: 400; letter-spacing: -0.18px; line-height: 24px; mso-line-height-rule: exactly; text-decoration: none; vertical-align: top; width: 100%;">
+                                        You're receiving this e-mail because you requested a password reset for your Politico account.
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td
+                                        style="padding-top: 24px; -ms-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; color: #9095a2; font-family: 'Postmates Std', 'Helvetica', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 16px; font-smoothing: always; font-style: normal; font-weight: 400; letter-spacing: -0.18px; line-height: 24px; mso-line-height-rule: exactly; text-decoration: none; vertical-align: top; width: 100%;">
+                                        Please click on the button below to reset your password.
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                        <a data-click-track-id="37" href="''' + link + '''"
+                                            style="margin-top: 36px; -ms-text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; color: #ffffff; font-family: 'Postmates Std', 'Helvetica', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif; font-size: 12px; font-smoothing: always; font-style: normal; font-weight: 600; letter-spacing: 0.7px; line-height: 48px; mso-line-height-rule: exactly; text-decoration: none; vertical-align: top; width: 220px; background-color: #F57C00; border-radius: 28px; display: block; text-align: center; text-transform: uppercase"
+                                            target="_blank">
+                                            Reset Password
+                                        </a>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </body>
+                </html>
+            '''
+            content = Content("text/html", message)
+            mail = Mail(from_email, subject, to_email, content)
+            response = sg.client.mail.send.post(request_body=mail.get())
+            print(response.status_code)
+            print(response.body)
+            print(response.headers)
+        except:
+            print("the was an error")
+
     def getSpecificUser(self):
         schema = SchemaGenerator(self.tableName, "email", None, "'" + self.id + "'").selectSpecific()
         db = Database(schema, True).executeQuery()
@@ -68,7 +225,8 @@ class AuthModel():
                 "status": 401,
                 "error": "You are fobidden to reset admin account"
             }
+        self.sendResetEmail(db["data"][0])
         return returnMessages.success(200, {
-            "data": db["data"],
+            "data": db["data"][0],
             "msg": "User retrieved successfully"
         })

--- a/app/api/v2/models/offices/office_model.py
+++ b/app/api/v2/models/offices/office_model.py
@@ -70,6 +70,7 @@ class OfficeModel():
         if valid["isValid"] is False:
             return valid["data"]
         schema = SchemaGenerator(self.propertyName, None, self.data, self.id).updateSpecific()
+        print(schema)
         db = Database(schema).executeQuery()
         if db["status"] == 400:
             return {

--- a/app/api/v2/views/auth/auth_view.py
+++ b/app/api/v2/views/auth/auth_view.py
@@ -29,3 +29,9 @@ def loginUser():
         response["data"]["token"] = token
         print(response["data"]["user"]["is_admin"])
     return jsonify(response), response["status"]
+
+
+@auth_view.route("/<email>", methods=["GET"])
+def getSpecificUser(email):
+    response = AuthModel(None, email).getSpecificUser()
+    return jsonify(response), response["status"]

--- a/app/api/v2/views/auth/auth_view.py
+++ b/app/api/v2/views/auth/auth_view.py
@@ -31,6 +31,14 @@ def loginUser():
     return jsonify(response), response["status"]
 
 
+@auth_view.route("/reset/<id>", methods=["PATCH"])
+@jwt_required
+def resetPassword(id):
+    response = AuthModel(request.get_json(force=True), id).resetPassword()
+    print(response)
+    return jsonify(response), response["status"]
+
+
 @auth_view.route("/<email>", methods=["GET"])
 def getSpecificUser(email):
     response = AuthModel(None, email, createToken(email)).getSpecificUser()

--- a/app/api/v2/views/auth/auth_view.py
+++ b/app/api/v2/views/auth/auth_view.py
@@ -33,5 +33,5 @@ def loginUser():
 
 @auth_view.route("/<email>", methods=["GET"])
 def getSpecificUser(email):
-    response = AuthModel(None, email).getSpecificUser()
+    response = AuthModel(None, email, createToken(email)).getSpecificUser()
     return jsonify(response), response["status"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,9 @@ PyJWT==1.6.1
 pytest==4.2.0
 pytest-cov==2.6.1
 python-dotenv==0.10.1
+python-http-client==3.1.0
 requests==2.21.0
+sendgrid==5.6.0
 six==1.12.0
 urllib3==1.24.1
 Werkzeug==0.14.1

--- a/tests/v2/auth/test_auth.py
+++ b/tests/v2/auth/test_auth.py
@@ -81,6 +81,9 @@ class TestAuth(unittest.TestCase):
     def post(self, path, data):
         return self.client.post(path=path, data=json.dumps(data), content_type='application/json')
 
+    def get(self, path):
+        return self.client.get(path=path, content_type='application/json')
+
     def test_register_user(self):
         response = self.post(self.endpoint + "/signup", self.signupData)
         self.assertEqual(response.status_code, 200)
@@ -96,6 +99,18 @@ class TestAuth(unittest.TestCase):
     def test_login(self):
         response = self.post(self.endpoint + "/login", self.loginData)
         self.assertEqual(response.status_code, 200)
+
+    def test_get_user(self):
+        response = self.get(self.endpoint + "/" + self.loginData["email"])
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_user_not_found(self):
+        response = self.get(self.endpoint + "/email20000@gmail.com")
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_admin(self):
+        response = self.get(self.endpoint + "/admin@gmail.com")
+        self.assertEqual(response.status_code, 401)
 
     def test_wrong_login(self):
         response = self.post(self.endpoint + "/login", self.wrongLoginData)

--- a/tests/v2/offices/test_offices.py
+++ b/tests/v2/offices/test_offices.py
@@ -97,7 +97,7 @@ class TestOffice(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_specific_office_results(self):
-        response = self.get(self.endpoint + "/2/result")
+        response = self.get(self.endpoint + "/1/result")
         self.assertEqual(response.status_code, 200)
 
     def test_specific_office_results_not_found(self):


### PR DESCRIPTION
**What does this PR do?**
Allows users to send a reset password request to API endpoint which later a password reset link is sent to their email address

**Description of Task to be completed?**

1. An object of user info is retrieved after a GET request

How should this be manually tested?
Go to github and clone repo https://github.com/jama5262/Politico, change to develop branch

1. Make sure to have the python virtualenv if not `pip install virtualenv`
2. Create the env with this command `virtualenv venv`
3. For windows `venv\Scripts\activate`, for Mac please Google to activate the env
4. Install the packages from the `requirements.txt` by using this commands `pip install -r requirements.txt`
5. And finally run `flask run`
6. To test the send reset password link to email address endpoint, open POSTMAN send a GET request to the endpoint `http://127.0.0.1:5000/api/v2/auth/<emailAddress>`

7. Success Response

```
{
    "data": {
        "data": {
            "email": "email6@gmail.com",
            "first_name": "John",
            "id": 7,
            "is_admin": false,
            "last_name": "Doe",
            "other_name": "Okay",
            "passport_url": "https://cdn3.iconfinder.com/data/icons/vector-icons-6/96/256-512.png",
            "password": "password1",
            "phone_number": "0711111116"
        },
        "msg": "Email reset link sent"
    },
    "status": 200
}
```
**What are the relevant pivotal tracker stories?**
[#164456667](https://www.pivotaltracker.com/n/projects/2241896)